### PR TITLE
Repair broken language map for the Chinese languages

### DIFF
--- a/langmap.json
+++ b/langmap.json
@@ -55,7 +55,7 @@
     "alias": ["zh-cn", "chinese-simplified"],
     "flag": "cn"
   },
-  "zh-cn": {
+  "zh-tw": {
     "alias": ["zh-tw", "chinese-traditional"],
     "flag": "cn"
   },


### PR DESCRIPTION
Since the key is the same for both traditional and simplified Chinese, only traditional may be used for translations. Simply changed the key to match the alias rather than use the same one as simplified.